### PR TITLE
closes #9 - Implements basic stats page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "hnssearch-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hnssearch-frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@heroicons/react": "^2.0.13",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "meilisearch": "^0.30.0",
+        "prettier": "^2.8.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.6.2",
@@ -13847,6 +13848,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -26853,6 +26868,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "prettier": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw=="
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "meilisearch": "^0.30.0",
+    "prettier": "^2.8.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.6.2",

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import {
 } from "react-router-dom";
 import HomePage from "./pages/HomePage";
 import ResultsPage from "./pages/ResultsPage";
+import StatsPage from "./pages/StatsPage";
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/search" element={<ResultsPage />} />
+          <Route path="/stats" element={<StatsPage />} />"
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </Router>

--- a/src/assets/files/stats.json
+++ b/src/assets/files/stats.json
@@ -1,0 +1,1 @@
+{"n_entries": 631, "n_domains": 211, "n_tlds": 126}

--- a/src/components/StatTile.js
+++ b/src/components/StatTile.js
@@ -2,8 +2,8 @@ import React from "react";
 
 function StatTile({ title, value }) {
   return (
-    <div className="flex items-center justify-center bg-white rounded-lg shadow-md p-4 text-center h-48">
-      <div className="flex flex-col justify-center">
+    <div className="flex items-center justify-center bg-white rounded-lg shadow-md p-4 text-center h-48 dark:bg-neutral-700">
+      <div className="flex flex-col justify-center text-gray-700 dark:text-neutral-200">
         <p className="text-4xl font-bold">{value}</p>
         <h2 className="text-lg font-medium mt-5 mb-2">{title}</h2>
       </div>

--- a/src/components/StatTile.js
+++ b/src/components/StatTile.js
@@ -1,0 +1,14 @@
+import React from "react";
+
+function StatTile({ title, value }) {
+  return (
+    <div className="flex items-center justify-center bg-white rounded-lg shadow-md p-4 text-center h-48">
+      <div className="flex flex-col justify-center">
+        <p className="text-4xl font-bold">{value}</p>
+        <h2 className="text-lg font-medium mt-5 mb-2">{title}</h2>
+      </div>
+    </div>
+  );
+}
+
+export default StatTile;

--- a/src/components/StatTile.js
+++ b/src/components/StatTile.js
@@ -2,7 +2,7 @@ import React from "react";
 
 function StatTile({ title, value }) {
   return (
-    <div className="flex items-center justify-center bg-white rounded-lg shadow-md p-4 text-center h-48 dark:bg-neutral-700">
+    <div className="md:h-48 flex items-center justify-center mb-10 bg-white rounded-lg shadow-md p-4 text-center dark:bg-neutral-700">
       <div className="flex flex-col justify-center text-gray-700 dark:text-neutral-200">
         <p className="text-4xl font-bold">{value}</p>
         <h2 className="text-lg font-medium mt-5 mb-2">{title}</h2>

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -46,6 +46,9 @@ function HomePage() {
           </Link>
         </div>
         <div className="flex space-x-3 items-center mr-3">
+          <Link className="link ml-3" to="/stats">
+            Stats
+          </Link>
           <a href="https://docs.hnssearch.io/" className="link">
             About
           </a>

--- a/src/pages/StatsPage.js
+++ b/src/pages/StatsPage.js
@@ -1,15 +1,42 @@
 import StatTile from "../components/StatTile";
 import stats from "../assets/files/stats.json";
+import { Link } from "react-router-dom";
+import React from "react";
+import Footer from "../components/Footer";
 
 // Implementation of stats currently with static file and import; will be changed to fetch at a later point.
 function StatsPage() {
   return (
-    <div className="flex flex-col justify-center py-8 px-4 bg-neutral-100 h-screen dark:bg-neutral-900">
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <StatTile title="Pages" value={stats.n_entries} />
-        <StatTile title="Different Sites" value={stats.n_domains} />
-        <StatTile title="Unique TLDs" value={stats.n_tlds} />
+    <div className="h-screen flex flex-col items-center justify-center bg-neutral-100  dark:bg-neutral-900">
+      <header className="flex w-full p-3 justify-between text-gray-800 text-lg dark:text-gray-300">
+        <div className="flex space-x-3 items-center">
+          <Link className="link ml-3" to="/dwebpulse">
+            dwebpulse
+          </Link>
+        </div>
+        <div className="flex space-x-3 items-center mr-3">
+          <Link className="link ml-3" to="/">
+            Search
+          </Link>
+          <a href="https://docs.hnssearch.io/" className="link">
+            About
+          </a>
+          {/*<Link className="link" to="/Settings">*/}
+          {/*  Settings*/}
+          {/*</Link>*/}
+        </div>
+      </header>
+      <div className="flex flex-col flex-grow w-full items-center">
+        <h1 className=" hidden text-gray-800 text-5xl dark:text-gray-300 mt-auto md:block">
+          HNSSearch Index
+        </h1>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 flex flex-col items-center mt-32 mb-auto w-4/5">
+          <StatTile title="Pages" value={stats.n_entries} />
+          <StatTile title="Different Sites" value={stats.n_domains} />
+          <StatTile title="Unique TLDs" value={stats.n_tlds} />
+        </div>
       </div>
+      <Footer />
     </div>
   );
 }

--- a/src/pages/StatsPage.js
+++ b/src/pages/StatsPage.js
@@ -4,7 +4,7 @@ import stats from "../assets/files/stats.json";
 // Implementation of stats currently with static file and import; will be changed to fetch at a later point.
 function StatsPage() {
   return (
-    <div className="flex flex-col justify-center h-screen py-8 px-4">
+    <div className="flex flex-col justify-center py-8 px-4 bg-neutral-100 h-screen dark:bg-neutral-900">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <StatTile title="Pages" value={stats.n_entries} />
         <StatTile title="Different Sites" value={stats.n_domains} />

--- a/src/pages/StatsPage.js
+++ b/src/pages/StatsPage.js
@@ -1,7 +1,17 @@
-import React from "react";
+import StatTile from "../components/StatTile";
+import stats from "../assets/files/stats.json";
 
+// Implementation of stats currently with static file and import; will be changed to fetch at a later point.
 function StatsPage() {
-  return <h1>Stats Page</h1>;
+  return (
+    <div className="flex flex-col justify-center h-screen py-8 px-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <StatTile title="Pages" value={stats.n_entries} />
+        <StatTile title="Different Sites" value={stats.n_domains} />
+        <StatTile title="Unique TLDs" value={stats.n_tlds} />
+      </div>
+    </div>
+  );
 }
 
 export default StatsPage;

--- a/src/pages/StatsPage.js
+++ b/src/pages/StatsPage.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+function StatsPage() {
+  return <h1>Stats Page</h1>;
+}
+
+export default StatsPage;


### PR DESCRIPTION
Creates a basic stats page with the following information:

- Total pages indexed
- unique TLD's
- total domains indexed (unique SLD's and TLD's

So far takes information from stats.json within the src folder. Should be later changed to use fetch from external source.