### PR TITLE
Adds code of conduct and contributing guidelines, updates readme

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to HNSSearch
+
+Thank you for considering contributing to HNSSearch! Your contributions, bug reports, enhancements, and suggestions are greatly appreciated.
+
+## Guidelines
+
+1. **Fork the Repository**: Fork the main hnssearch-frontend repository on GitHub.
+
+2. **Clone Your Fork**: Clone your fork locally to your machine.
+
+3. **Create a Branch**: Create a new branch for your feature or bugfix. Use a descriptive name, such as `feature/your-feature-name` or `bugfix/your-bugfix-name`.
+
+4. **Write Code**: Make your changes, add new features, or fix bugs, adhering to the existing code style.
+
+5. **Write Tests**: If applicable, write tests to verify your changes.
+
+6. **Update Documentation**: Update the README.md or any relevant documentation to reflect your changes.
+
+7. **Commit Your Changes**: Commit your changes with a clear and descriptive commit message.
+
+8. **Push to GitHub**: Push your branch to GitHub.
+
+9. **Submit a Pull Request**: Submit a pull request against the main repository's `main` or appropriate branch.
+
+10. **Respond to Feedback**: Respond to feedback from maintainers and make necessary changes if requested.
+
+## Code of Conduct
+
+By participating in this project, you agree to abide by the project's Code of Conduct. Please read and follow the [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
+
+## Getting Help
+
+If you have any questions or need help, please open an issue in the GitHub repository or contact the maintainers.
+
+## Thank You!
+
+Thank you for contributing to HNSSearch. Your time and effort are greatly appreciated by the community!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hnssearch-frontend
+# HNSSearch frontend
 
 hnssearch is an open-source search engine for the [Handshake](https://handshake.org/) community. It is currently in alpha and is being actively developed.
 
@@ -29,6 +29,9 @@ npm start
 ```
 
 This will start the development server on http://localhost:3000. You can access the search engine by navigating to that address in your web browser.
+
+## Contributing
+Contributions are welcome! Please read the [CONTRIBUTING.md](./CONTRIBUTING.md) file for guidelines.
 
 ## License
 


### PR DESCRIPTION
The repo did not have any contributing guidelines and no code of conduct. This PR adds those and references them in the readme file. Additionally, changes title in readme from hnssearch-frontend to HNSSearch frontend to be more readable.